### PR TITLE
APM-2600 Re-enabling INT deployments

### DIFF
--- a/azure/azure-release-pipeline.yml
+++ b/azure/azure-release-pipeline.yml
@@ -34,6 +34,6 @@ extends:
     proxy_path: ''
     apigee_deployments:
       - environment: internal-dev
-      # - environment: int
-      #   depends_on:
-      #       - internal_dev
+      - environment: int
+        depends_on:
+          - internal_dev


### PR DESCRIPTION
During conversion into spec-only repo as part of ADZ-2600, deployments to INT environment were disabled.

INT is where Bloomreach imports API specifications from, and so the above action stopped updates to the spec from propagating to NHSD website.

The current change aims to restore this propagation by re-enabling deployments to INT.